### PR TITLE
Feature/cleanup11 - RSS Feed Support 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 
 Source code to the [Code Chefs Podcast](https://codechefs.dev) site! Feel free to peruse around the source code, although it may be slightly messy
 
-This theme is based on [Gatsby-Hooks-Starter-Theme](https://github.com/vincentntang/gatsby-hooks-starter-theme), another theme I made
-
+This theme is based on [Gatsby-Hooks-Starter-Theme](https://github.com/vincentntang/gatsby-hooks-starter-theme)
 Some of the coolest parts of this repo are the following:
 
 1. A custom React Audio Library that controls playback speed, volume levels, and timestamps that can autoplay
-2. Fully responsive sass library support based on this [scss library](https://github.com/vincentntang/freshpoint) I made
+2. Fully responsive sass library support based on this [scss library](https://github.com/vincentntang/freshpoint)
 
 ## Installation Notes
 

--- a/content/08-01-2020-preview-episode.md
+++ b/content/08-01-2020-preview-episode.md
@@ -3,8 +3,10 @@ title: "Preview Episode"
 slug: "preview-episode"
 # cover: "img/arnold.jpeg"
 cover: "8.jpg"
-date: "2020-08-01"
-audioUrl: "https://codechefs.s3.amazonaws.com/000_preview_episode.mp3"
+date: 2020-08-01
+audioPath: 000_preview_episode.mp3
+fileSize: 17.6
+showLength: 15:24
 category: "tech"
 shortDescription: "A brief introduction to ourselves and the show!"
 tags:

--- a/content/09-01-2020-first-developer-jobs.md
+++ b/content/09-01-2020-first-developer-jobs.md
@@ -3,8 +3,10 @@ title: "First Developer Jobs"
 slug: "first-developer-jobs"
 # cover: "img/arnold.jpeg"
 cover: "8.jpg"
-date: "2020-09-02"
-audioUrl: "https://codechefs.s3.amazonaws.com/001_first_developer_jobs.mp3"
+date: 2020-09-02
+audioPath: 001_first_developer_jobs.mp3
+fileSize: 39.4
+showLength: 34:26
 category: "tech"
 shortDescription: "What's it like working in your first developer job? German and Vincent discuss their restaurant history background before webdevelopment and how they successfully transitioned into tech!"
 tags:

--- a/data/SiteConfig.js
+++ b/data/SiteConfig.js
@@ -8,9 +8,9 @@ const config = {
   siteDescription: "Podcast Site For Hungry Web Developers", // Website description used for RSS feeds/meta description tag.
   siteRss: "/rss.xml", // Path to the RSS file.
   siteRssTitle: "Code Chefs RSS feed", // Title of the RSS feed
-  siteFBAppID: "1825356251115265", // FB Application ID for using app insights
-  googleAnalyticsID: "UA-47311644-5", // GA tracking ID.
-  disqusShortname: "https-vagr9k-github-io-gatsby-advanced-starter", // Disqus shortname.
+  // siteFBAppID: "1825356251115265", // FB Application ID for using app insights
+  // googleAnalyticsID: "UA-47311644-5", // GA tracking ID.
+  // disqusShortname: "https-vagr9k-github-io-gatsby-advanced-starter", // Disqus shortname.
   dateFromFormat: "YYYY-MM-DD", // Date format used in the frontmatter.
   dateFormat: "MM/DD/YYYY", // Date format for display.
   postsPerPage: 9999, // Amount of posts displayed per listing page.
@@ -18,9 +18,8 @@ const config = {
   userEmail: "vincentntang@gmail.com", // Email used for RSS feed's author segment
   userTwitter: "codechefsdev", // Optionally renders "Follow Me" in the UserInfo segment.
   userLocation: "Florida, USA", // User location to display in the author segment.
-  userAvatar: "https://api.adorable.io/avatars/150/test.png", // User avatar to display in the author segment.
-  userDescription:
-    "Yeah, I like animals better than people sometimes... Especially dogs. Dogs are the best. Every time you come home, they act like they haven't seen you in a year. And the good thing about dogs... is they got different dogs for different people.", // User description to display in the author segment.
+  userAvatar: "https://www.codechefs.dev/logos/vincentntang.jpeg", // User avatar to display in the author segment.
+  userDescription: "Code Chefs is a podcast for web developers who want to level up! We do all topics ranging from frontend to backend development",
   // Links to social profiles/projects you want to display in the author segment/navigation bar.
   userLinks: [
     {

--- a/data/SiteConfig.js
+++ b/data/SiteConfig.js
@@ -1,4 +1,5 @@
 const config = {
+  s3bucket: 'https://codechefs.s3.amazonaws.com/',
   siteTitle: "Code Chefs Developer Podcast", // Site title.
   siteTitleShort: "Code Chefs", // Short site title for homescreen (PWA). Preferably should be under 12 characters to prevent truncation.
   siteTitleAlt: "Code Chefs Web Developer Podcast", // Alternative site title for SEO.
@@ -7,7 +8,7 @@ const config = {
   pathPrefix: "/", // Prefixes all links. For cases when deployed to example.github.io/gatsby-advanced-starter/.
   siteDescription: "Podcast Site For Hungry Web Developers", // Website description used for RSS feeds/meta description tag.
   siteRss: "/rss.xml", // Path to the RSS file.
-  siteRssTitle: "Code Chefs RSS feed", // Title of the RSS feed
+  siteRssTitle: "Code Chefs - Podcast for Hungry Web Developers", // Title of the RSS feed
   // siteFBAppID: "1825356251115265", // FB Application ID for using app insights
   // googleAnalyticsID: "UA-47311644-5", // GA tracking ID.
   // disqusShortname: "https-vagr9k-github-io-gatsby-advanced-starter", // Disqus shortname.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -146,7 +146,7 @@ module.exports = {
           { 'itunes:author': 'Vincent Tang &amp German Gamboa - Fullstack Developers' },
           { 'itunes:explicit': 'clean'},
           { 'itunes:subtitle': "Podcast for Hungry Web Developers"},
-          { 'itunes:summary': "Fullstack Developers Vincent Tang and German Gamboa deep dive into topics in web development! They discuss from their own set of experience, and what life is like in tech. Topics range from Javascript, React, Backend Development, Soft Skills, and more! "},
+          { 'itunes:summary': "Fullstack Developers Vincent Tang and German Gamboa deep dive into topics in web development! They discuss from their own set of experiences, and what life is like in tech. Topics range from Javascript, React, Backend Development, Soft Skills, and more! "},
           { 'itunes:owner': [
             {'itunes:name': "Vincent Tang"},
             {'itunes:email': "vincentntang@gmail.com"}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -183,6 +183,9 @@ module.exports = {
             {'link': 'https://codechefs.dev'},
           ]},
           {
+            'link': 'https://codechefs.dev'
+          },
+          {
             'itunes:keywords':"javascript, webdevelopment,html,css,js"
           },
         ],
@@ -203,12 +206,12 @@ module.exports = {
                   // { author: config.userEmail },
                   { "itunes:author":"Vincent Tang and German Gamboa - Fullstack Developers"},
                   { "itunes:subtitle": edge.node.excerpt},
-                  { "itunes:duration": 1234},
+                  { "itunes:duration": edge.node.frontmatter.showLength},
                   {"itunes:explicit": "no"},
                   {'enclosure': [
                     {_attr: {
-                      url: '12345',
-                      length: "123123123",
+                      url: config.s3bucket + edge.node.frontmatter.audioPath,
+                      length: Number(edge.node.frontmatter.fileSize) * 1000 * 1000, // megabytes to bytes
                       type: "audio/mpeg",
                     }},
                   ]},
@@ -238,7 +241,9 @@ module.exports = {
                       category
                       tags
                       shortDescription
-                      audioUrl
+                      audioPath
+                      showLength
+                      fileSize
                     }
                   }
                 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -69,7 +69,7 @@ exports.createPages = async ({ graphql, actions }) => {
               category
               date
               shortDescription
-              audioUrl
+              audioPath
             }
           }
         }
@@ -155,7 +155,7 @@ exports.createPages = async ({ graphql, actions }) => {
       path: edge.node.fields.slug,
       component: postPage,
       context: {
-        audioUrl: edge.node.frontmatter.audioUrl,
+        audioPath: edge.node.frontmatter.audioPath,
         shortDescription: edge.node.frontmatter.shortDescription,
         slug: edge.node.fields.slug,
         nexttitle: nextEdge.node.frontmatter.title,

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -15,7 +15,7 @@ const AboutPage = () => {
         <Helmet title={`About | ${config.siteTitle}`} />
         <div className="cc-header cc-card">
           <div className="cc-padding cc-intro">
-            <h3 className="color-offgray">What is Code Chefs?</h3>
+            <h3 className="color-offgray mt-0">What is Code Chefs?</h3>
             <p className="my-0">It's a podcast for web developers who wants to level up! We do talks for all skill levels on:</p>
             <ul>
               <li>Javascript (React, Vue, Angular)</li>

--- a/src/pages/support.jsx
+++ b/src/pages/support.jsx
@@ -10,7 +10,7 @@ const AboutPage = () => {
         <Helmet title={`About | ${config.siteTitle}`} />
         <div className="cc-card">
           <div className="cc-padding cc-support">
-            <h3 className="color-offgray">Thanks for dining with us!</h3>
+            <h3 className="color-offgray mt-0">Thanks for dining with us!</h3>
             <p>If you'd like to support us, follow us on <a className="newsletter-link" href="https://twitter.com/codechefsdev">twitter! </a></p>
             <p>We're looking to air an episode a week</p>
             <p>Subscribe to our <a className="newsletter-link" href="https://tinyletter.com/vincentntang">newsletter</a> for more Javascript related content!</p>

--- a/src/templates/post.jsx
+++ b/src/templates/post.jsx
@@ -40,7 +40,7 @@ export default class PostTemplate extends React.Component {
                 <Audio 
                   id={1} 
                   index={1} 
-                  mp3={post.audioUrl}
+                  mp3={config.s3bucket + post.audioPath}
                   episodeName={post.title}
                   episodeHtml={postNode.html}
                   // currentTrack={currentTrack} 
@@ -84,7 +84,7 @@ export const pageQuery = graphql`
         date
         category
         tags
-        audioUrl
+        audioPath
         shortDescription
       }
       fields {


### PR DESCRIPTION
Adds the addition of 

- ShowLength
- AudioPath
- FileSize
- Link to site

These are manually declared under the YML File, deploying to development to and testing against podcast-connect
https://podcastsconnect.apple.com/my-podcasts/new-feed to see if it works successfully