### PR TITLE
Update play state using the audio's 'paused' property.

### DIFF
--- a/src/components/audio/Audio.jsx
+++ b/src/components/audio/Audio.jsx
@@ -51,12 +51,13 @@ const Audio = ({ mp3, index, episodeName }) => {
   }, [curSpeed, curVolume])
 
 
-
+  useEffect(() => {
+    playerRef.current.paused ? setPlaying(false) : setPlaying(true);
+  })
 
   const toggleAudio = async () => {
     try {
-      playing ? await playerRef.current.pause() : await playerRef.current.play()
-      setPlaying(s => !s)
+      playing ? await playerRef.current.pause() : await playerRef.current.play();
     } catch (error) {
       console.error(error)
     }


### PR DESCRIPTION
Essentially this allows for the play/pause icon to be updated when audio is paused without clicking on the button itself. 
Before the play state was not updating when I played or paused with my media shortcuts meaning I'd have to double click the button to update the state. 